### PR TITLE
Fix inventory file root credentials example

### DIFF
--- a/inventory
+++ b/inventory
@@ -19,8 +19,8 @@ pi_ip=192.168.1.29
 pi_prefix=24
 pi_gateway=192.168.1.1
 pi_dns=8.8.8.8
-# pubkey: 'ssh-rsa AAAA... user@domain.com'
-# rootpasswordhash: 'ROOTHASHHERE'
+# pubkey='ssh-rsa AAAA... user@domain.com'
+# rootpasswordhash='ROOTHASHHERE'
 # To be implemented at a later stage:
 # ssid="MYSSID"
 # wifi_password="MYWIFIPASSWORD"


### PR DESCRIPTION
The inventory file is written in a `ini` format, the key-value delimiter
should be `=` and not `:`