### PR TITLE
Change the checksum verification of the downloads

### DIFF
--- a/roles/arm-image/tasks/fetch.yml
+++ b/roles/arm-image/tasks/fetch.yml
@@ -69,13 +69,21 @@
   register: download
 - debug: var=download
 
+- name: "Get the content of {{ workpath }}/{{ urlchecksum | basename }}"
+  slurp:
+    src: "{{ workpath }}/{{ urlchecksum | basename }}"
+  register: image_checksum_b64
+
+- name: Get the actual checksum
+  set_fact:
+    image_checksum: "{{ image_checksum_b64.content | b64decode | regex_search('[0-9a-f]{64}') }}"
+- debug: var=image_checksum
+
 - name: "Download the image from {{ url }}"
   get_url:
     url: "{{ url }}"
     dest: "{{ workpath }}/{{ url | basename }}"
     checksum: 'sha256:{{ image_checksum }}'
-  vars:
-    image_checksum: '{{ lookup("file", "{{ workpath }}/{{ urlchecksum | basename }}") | regex_search("[0-9a-f]{64}") }}'
   register: download
 - debug: var=download
 


### PR DESCRIPTION
The `lookup` plugin is evaluated on the ansible controller rather than
the target (See [1]), though we download the checksum file to the target
machine.
Changed the `fetch.yaml` to evaluate the downloaded file on the target.

[1] https://docs.ansible.com/ansible/latest/plugins/lookup.html