### PR TITLE
Allow setting the device hostname in the image

### DIFF
--- a/inventory
+++ b/inventory
@@ -19,6 +19,7 @@ pi_ip=192.168.1.29
 pi_prefix=24
 pi_gateway=192.168.1.1
 pi_dns=8.8.8.8
+#pi_hostname=my-pi-host.my-domain
 # pubkey='ssh-rsa AAAA... user@domain.com'
 # rootpasswordhash='ROOTHASHHERE'
 # To be implemented at a later stage:

--- a/roles/arm-image/tasks/configure-root.yml
+++ b/roles/arm-image/tasks/configure-root.yml
@@ -32,6 +32,14 @@
     regexp: '^root:'
   when: rootpasswordhash is defined
 
+- name: Set hostname
+  become: yes
+  copy:
+    dest: /etc/hostname
+    content: |
+      '{{ pi_hostname }}'
+  when: pi_hostname is defined
+
 - name: Permit root login via ssh
   become: yes
   lineinfile:


### PR DESCRIPTION
Allow setting the device name by manipulating the `/etc/hostname` file
using an inventory variable.